### PR TITLE
Add some functionality to parse out the tide_station_id

### DIFF
--- a/lib/ndbc/station.rb
+++ b/lib/ndbc/station.rb
@@ -13,7 +13,7 @@ module NDBC
 
     attr_accessor :id, :connection
     attr_reader :owner, :ttype, :hull, :name, :payload, :location, :timezone, :forecast, :note,
-                :active
+                :active, :tide_station_id
 
     alias_method :active?, :active
 
@@ -29,6 +29,7 @@ module NDBC
       @forecast = station_data[:forecast]
       @note = station_data[:note]
       @active = station_data[:active]
+      @tide_station_id = station_data[:tide_station_id]
       @connection = Connection.new
     end
 

--- a/lib/ndbc/station_table.rb
+++ b/lib/ndbc/station_table.rb
@@ -18,12 +18,18 @@ module NDBC
             time_zone:  station_parts[7],
             forecast:   station_parts[8],
             note:       station_parts[9],
-            active:     active?(station_parts)
+            active:     active?(station_parts),
+            tide_station_id: tide_station_id(station_parts[4])
           }
         end
       end
 
       private
+
+      def tide_station_id(name)
+        return '' unless name
+        name.match(/\d{7}/).to_s
+      end
 
       def cleanup_parts!(station_parts)
         station_parts.map! do |part|


### PR DESCRIPTION
This station id is used for the tidesandcurrents.noaa.gov api. I'm not a big fan of this attribute name, but I can't think of anything better. On their site, it's just called "station id", but we're already using that for the first field of the station table.
